### PR TITLE
Fix serial command parser

### DIFF
--- a/real-time_control_python/py_controller.py
+++ b/real-time_control_python/py_controller.py
@@ -1,8 +1,11 @@
-"""Listens for serial commands like: SET_SPEED 1500\n
+"""Simple helper script to send serial commands to the RollerCAN driver.
 
-Parses them
+Example usage::
 
-Sends I²C commands to the RollerCAN driver"""
+    SET_SPEED 1500
+    SET_MODE POS
+    SET_POSITION 9000
+"""
 
 import serial
 import time

--- a/real-time_control_python/src/main.cpp
+++ b/real-time_control_python/src/main.cpp
@@ -81,11 +81,30 @@ void moveToNormalizedPosition(int32_t targetDegrees) {
 }
 
 void processSerialCommand() {
+    inputString.trim();
     if (inputString.startsWith("SET_SPEED")) {
-        int speed = inputString.substring(10).toInt(); // Skip "SET_SPEED " and convert to int
+        int speed = inputString.substring(10).toInt();
         approachSpeed = speed;  // Speed in 0.01 rpm units
         setMotorSpeed(approachSpeed);
-        Serial.printf("Speed set to %.2f rpm\n", speed/100.0f);
+        Serial.printf("Speed set to %.2f rpm\n", speed / 100.0f);
+    } else if (inputString.startsWith("SET_POSITION")) {
+        targetPosition = inputString.substring(12).toInt();
+        positionMode = true;
+        roller.setMode(MODE_POS);
+        roller.setSpeed(approachSpeed);
+        roller.setPosition(targetPosition);
+        Serial.printf("Target position: %d deg\n", targetPosition / 100);
+    } else if (inputString.startsWith("SET_MODE")) {
+        String mode = inputString.substring(9);
+        mode.trim();
+        mode.toUpperCase();
+        if (mode == "POS") {
+            roller.setMode(MODE_POS);
+            positionMode = true;
+        } else if (mode == "SPEED") {
+            roller.setMode(MODE_SPEED);
+            positionMode = false;
+        }
     }
     // Clear the string for next command
     inputString = "";


### PR DESCRIPTION
## Summary
- rename `py_controler.py` -> `py_controller.py`
- expand firmware `processSerialCommand` to understand position and mode commands
- clarify documentation comment in Python helper

## Testing
- `python3 -m py_compile real-time_control_python/py_controller.py`
- `g++ -std=c++17 -c real-time_control_python/src/main.cpp -Ireal-time_control_python/src -DM5STACK_CORE2` *(fails: `M5Core2.h` not found)*
